### PR TITLE
Add support for 'make cppcheck'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL
 PKG_INSTALLDIR
+AM_EXTRA_RECURSIVE_TARGETS([cppcheck])
 
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
@@ -20,6 +21,11 @@ AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests],
               [Build install tests (default: no)]),
               [], [enable_tests=no])
 AM_CONDITIONAL(PT_TESTS, [test x$enable_tests = xyes])
+
+# Support for cppcheck static analyser
+AC_SUBST([CPPCHECK], 'cppcheck')
+AC_SUBST([CPPCHECK_FLAGS], '--std=c11 --quiet --error-exitcode=1')
+AC_SUBST([CPPCHECK_DEFRULE], '$(CPPCHECK) $(CPPCHECK_FLAGS) $(DEFS) $(AM_CPPFLAGS) $(DEFAULT_INCLUDES) $(INCLUDES) $(SOURCES)')
 
 AC_CONFIG_FILES([
   Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,3 +19,5 @@ libpainter_la_SOURCES = painter.c painter_utils.c painter_utils.h
 
 libpainter_la_LIBADD =
 
+cppcheck-local:
+	$(AM_V_at)$(CPPCHECK_DEFRULE)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,3 +17,5 @@ paintertest_LDADD = \
 
 paintertest_LDFLAGS = $(EXTRA_FLAGS)
 
+cppcheck-local:
+	$(AM_V_at)$(CPPCHECK_DEFRULE)


### PR DESCRIPTION
This PR has been  prompted by  neutrinolabs/xrdp#1469 and neutrinolabs/xrdp#1473, both raised by @chipitsine

The change allows 'make cppcheck' to be used to run the cppcheck static analysis utility on the sources, failing if problems are found.

The intention is eventually to add 'make cppcheck' to the xrdp CI jobs, so that detection of such issues becomes automatic.

The reason I'm submitting this for consideration in this repo rather than the main xrdp repo is that both libpainter and librfxcodec need to support 'make cppcheck' before it can be added to xrdp.  This repo is the simplest to start with.

This is my first effort at hacking autoconf. Maybe it shows.