### PR TITLE
Force static library only

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@ AM_CFLAGS = \
 
 lib_LTLIBRARIES = libpainter.la
 
-libpainter_la_LDFLAGS =
+libpainter_la_LDFLAGS = -all-static
 
 libpainter_ladir = $(moduledir)
 


### PR DESCRIPTION
See neutrinolabs/xrdp#1467

This library is only statically linked, so there's not need to build the dynamic one. If `--disable-static` is specified for the xrdp configure, this library still needs to be statically linked.