### PR TITLE
Update autoconf version to 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 # Process this file with autoconf to produce a configure script
 
-AC_PREREQ(2.59)
+AC_PREREQ(2.69)
 AC_INIT([libpainter], [0.1.1], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.6 foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_C_CONST
-AC_PROG_LIBTOOL
+LT_INIT
 PKG_INSTALLDIR
 
 # Use silent rules by default if supported by Automake


### PR DESCRIPTION
The version of autoconf on Ubuntu 22.04 (2.71) produces warnings regarding obsolete macros AC_PROG_LIBTOOL

This PR bumps the autoconf version to 2.69 (used by CentOS 7 and Ubuntu 16.04) and replaces the obsolete macro with the supported one.
